### PR TITLE
Add string representation for FigoException

### DIFF
--- a/figo/figo.py
+++ b/figo/figo.py
@@ -60,6 +60,9 @@ class FigoException(Exception):
         self.error = error
         self.error_description = error_description
 
+    def __str__(self):
+        return repr(self.error_description)
+
     @classmethod
     def from_dict(cls, dictionary):
         return cls(dictionary['error'], dictionary['error_description'])


### PR DESCRIPTION
Added a string representation for FigoException, so that the error description is printed along with the exception in the stacktrace.
