### PR TITLE
Fix unresolved import of FigoException in models

### DIFF
--- a/figo/exception.py
+++ b/figo/exception.py
@@ -1,0 +1,22 @@
+#
+#  Created by Matthias Jacob on 2013-08-19.
+#  Copyright (c) 2013 figo GmbH. All rights reserved.
+#
+
+
+class FigoException(Exception):
+    """Base class for all exceptions transported via the figo connect API.
+
+    They consist of a code-like `error` and a human readable `error_description`.
+    """
+
+    def __init__(self, error, error_description):
+        self.error = error
+        self.error_description = error_description
+
+    def __str__(self):
+        return repr(self.error_description)
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        return cls(dictionary['error'], dictionary['error_description'])

--- a/figo/figo.py
+++ b/figo/figo.py
@@ -15,6 +15,7 @@ import urllib
 
 
 from .models import Account, Notification, Transaction
+from .exception import FigoException
 
 
 logger = logging.getLogger(__name__)
@@ -48,24 +49,6 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
             fingerprint = ":".join(["".join(x) for x in izip_longest(*[iter(fingerprint.upper())]*2)])
             if not fingerprint in VerifiedHTTPSConnection.VALID_FINGERPRINTS:
                 raise ssl.SSLError("Certificate validation failed")
-
-
-class FigoException(Exception):
-    """Base class for all exceptions transported via the figo connect API.
-
-    They consist of a code-like `error` and a human readable `error_description`.
-    """
-
-    def __init__(self, error, error_description):
-        self.error = error
-        self.error_description = error_description
-
-    def __str__(self):
-        return repr(self.error_description)
-
-    @classmethod
-    def from_dict(cls, dictionary):
-        return cls(dictionary['error'], dictionary['error_description'])
 
 
 class FigoConnection(object):

--- a/figo/models.py
+++ b/figo/models.py
@@ -3,6 +3,7 @@
 #  Copyright (c) 2013 figo GmbH. All rights reserved.
 #
 
+from .exception import FigoException
 
 class ModelBase(object):
     


### PR DESCRIPTION
This resolves the missing import of FigoException in the models module. In order to avoid a circular dependency between the figo and models modules, the exception was refactored out into its own package.

NOTE that this pull request is built on top of #1, so it might be reasonable to merge that one first.
