### PR TITLE
remove reassignment of `sync_poll_retry`

### DIFF
--- a/figo/figo.py
+++ b/figo/figo.py
@@ -389,6 +389,7 @@ class FigoSession(FigoObject):
 
         :Parameters:
          - `access_token` - the access token to bind this session to a user
+         - `sync_poll_retry` - maximum number of synchronization poll retries
         """
         self.access_token = access_token
         self.headers = {
@@ -396,7 +397,7 @@ class FigoSession(FigoObject):
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'User-Agent': USER_AGENT}
-        self.sync_poll_retry = 20
+        self.sync_poll_retry = sync_poll_retry
 
     @property
     def accounts(self):
@@ -1148,7 +1149,7 @@ class FigoSession(FigoObject):
 
     def get_sync_url(self, state, redirect_uri):
         """
-        URL to trigger a synchronisation.
+        URL to trigger a synchronization.
 
         The user should open this URL in a web browser to synchronize his/her accounts with
         the respective bank servers. When the process is finished, the user is


### PR DESCRIPTION
`FigoSession` constructor reassigned the value to 20 although it was passed as argument