### PR TITLE
hotfix unicode error in logging

### DIFF
--- a/figo/models.py
+++ b/figo/models.py
@@ -661,8 +661,16 @@ class TaskState(ModelBase):
 
     def __str__(self, *args, **kwargs):
         """Short String representation of a TaskState."""
-        return "TaskState: '{self.message}' erroneous: {self.is_erroneous} " \
-               "ended: {self.is_ended}".format(self=self)
+        string = (u"TaskState: '{self.message}' "
+                   "(is_erroneous: {self.is_erroneous}, "
+                   "is_ended: {self.is_ended})")
+
+        # BBB(Valentin): All strings come in UTF-8 from JSON. But:
+        #   - python2.6: encode knows no kwargs
+        #   - python2.7: `u"{0}".format(x)` returns `unicode`, `__str__()` excpects `str` (ASCII)
+        #   - python3.x: encode returns `bytes`,`__str__` expects `str` (UTF-8)
+        #   This is really ugly, but works in all pythons.
+        return str(string.format(self=self).encode('ascii','replace'))
 
 
 class Challenge(ModelBase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -209,6 +209,15 @@ def test_create_task_token_from_dict(demo_session):
     assert isinstance(task_token, TaskToken)
 
 
+def test_task_token_unicode_logging():
+    data = {
+        'message': u"\xc3",
+        'is_erroneous': False,
+        'is_ended': False,
+    }
+    assert '?' in str(TaskState.from_dict(TaskState, data))
+
+
 def test_create_task_state_from_dict(demo_session):
     data = {
         "account_id": "A1.2",


### PR DESCRIPTION
Task token logging was broken, since `format()` tried to press the UTF-8 task token message into ASCII. `TaskToken.__str__()` now escapes non-ASCII with `?`. Use `TaskToken.message` to present the message.

Also updated the docstrings.