### PR TITLE
fix: Only set content-type header if there is content

### DIFF
--- a/figo/figo.py
+++ b/figo/figo.py
@@ -93,7 +93,6 @@ class FigoObject(object):
         """
         self.headers = {
             'Accept': 'application/json',
-            'Content-Type': 'application/json',
             'User-Agent': "python_figo/{0}".format(__version__),
         }
         self.language = language
@@ -116,6 +115,8 @@ class FigoObject(object):
 
         session = Session()
         session.headers.update(self.headers)
+        if data is not None:
+            session.headers['Content-Type'] = 'application/json'
 
         for fingerprint in self.fingerprints:
             session.mount(self.api_endpoint, FingerprintAdapter(fingerprint.lower()))


### PR DESCRIPTION
Due to recent fixes in the api this needs to be adjusted.