### PR TITLE
Fix hardcoded fingerprints botched in 3998871

### DIFF
--- a/figo/credentials.py
+++ b/figo/credentials.py
@@ -5,10 +5,11 @@ DEMO_CREDENTIALS = {
     'client_secret': 'Sv9-vNfocFiTe_NoMRkvNLe_jRRFeESHo8A0Uhyp7e28',
     'api_endpoint': 'https://api.figo.me',
     # string containing comma-separated list of SSL fingerprints
-    'ssl_fingerprints': ('79:B2:A2:93:00:85:3B:06:92:B1:B5:F2:24:79:48:58:'
-                         '3A:A5:22:0F:C5:CD:E9:49:9A:C8:45:1E:DB:E0:DA:50',
-                         'CD:F3:D3:26:27:89:91:B9:CD:AE:4B:10:6C:96:81:B7:'
-                         'EB:B3:38:10:C4:72:37:6A:4D:9C:84:B7:B3:DC:D6:8D'),
+    'ssl_fingerprints': '79:B2:A2:93:00:85:3B:06:92:B1:B5:F2:24:79:48:58:'
+                        '3A:A5:22:0F:C5:CD:E9:49:9A:C8:45:1E:DB:E0:DA:50'
+                        ','
+                        'CD:F3:D3:26:27:89:91:B9:CD:AE:4B:10:6C:96:81:B7:'
+                        'EB:B3:38:10:C4:72:37:6A:4D:9C:84:B7:B3:DC:D6:8D',
 }
 
 DEMO_TOKEN = ('ASHWLIkouP2O6_bgA2wWReRhletgWKHYjLqDaqb0LFfamim9RjexTo'

--- a/figo/credentials.py
+++ b/figo/credentials.py
@@ -5,10 +5,7 @@ DEMO_CREDENTIALS = {
     'client_secret': 'Sv9-vNfocFiTe_NoMRkvNLe_jRRFeESHo8A0Uhyp7e28',
     'api_endpoint': 'https://api.figo.me',
     # string containing comma-separated list of SSL fingerprints
-    'ssl_fingerprints': '79:B2:A2:93:00:85:3B:06:92:B1:B5:F2:24:79:48:58:'
-                        '3A:A5:22:0F:C5:CD:E9:49:9A:C8:45:1E:DB:E0:DA:50'
-                        ','
-                        'CD:F3:D3:26:27:89:91:B9:CD:AE:4B:10:6C:96:81:B7:'
+    'ssl_fingerprints': 'CD:F3:D3:26:27:89:91:B9:CD:AE:4B:10:6C:96:81:B7:'
                         'EB:B3:38:10:C4:72:37:6A:4D:9C:84:B7:B3:DC:D6:8D',
 }
 


### PR DESCRIPTION
Fingerprints are expected to be a comma-separated string, not a tuple. Unneeded
parens confused the committer, so remove them.

This failure was not caught by CI, because hardcoded SDK fingerprints are
overwritten via an environment variable.

Signed-off-by: Yury V. Zaytsev <yury.zaytsev@moneymeets.com>